### PR TITLE
Add IPv6 listeners to vhost templates and Cloudflare ranges

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -60,6 +60,13 @@ http {
     set_real_ip_from 162.158.0.0/15;
     set_real_ip_from 104.16.0.0/12;
     set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2a06:98c0::/29;
+    set_real_ip_from 2c0f:f248::/32;
     real_ip_header CF-Connecting-IP;
 
     fastcgi_connect_timeout 90;

--- a/scripts/vhost-fastcgi
+++ b/scripts/vhost-fastcgi
@@ -2,7 +2,9 @@ fastcgi_cache_path /etc/nginx/mycache/domain.com levels=1:2 keys_zone=domain.com
 
 server {
   listen 80;
+  listen [::]:80;
   listen 443 ssl http2;
+  listen [::]:443 ssl http2;
   ssl_certificate /etc/ssl/domain.com/domain.com.crt;
   ssl_certificate_key /etc/ssl/domain.com/domain.com.key;
   root /var/www/domain.com;

--- a/scripts/vhost-nocache
+++ b/scripts/vhost-nocache
@@ -1,6 +1,8 @@
 server {
   listen 80;
+  listen [::]:80;
   listen 443 ssl http2;
+  listen [::]:443 ssl http2;
   ssl_certificate /etc/ssl/domain.com/domain.com.crt;
   ssl_certificate_key /etc/ssl/domain.com/domain.com.key;
   root /var/www/domain.com;

--- a/scripts/vhost-nocache-invoiceninja
+++ b/scripts/vhost-nocache-invoiceninja
@@ -1,6 +1,8 @@
 server {
   listen 80;
+  listen [::]:80;
   listen 443 ssl http2;
+  listen [::]:443 ssl http2;
   ssl_certificate /etc/ssl/domain.com/domain.com.crt;
   ssl_certificate_key /etc/ssl/domain.com/domain.com.key;
   root /var/www/domain.com/public;


### PR DESCRIPTION
## Summary
- add IPv6 listen directives to the vhost templates so generated server blocks bind on both stacks
- register Cloudflare IPv6 networks in the nginx real IP allow list to preserve client IPs

## Testing
- manual placeholder substitution test for vhost template
- `bash scripts/main-menu/ipv6.sh` *(fails: ip command not available in container)*
- `nginx -t` *(fails: nginx not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b9690e10832390846cd42cdde7d8