### PR TITLE
Improve IPv6 automation and TLS directives

### DIFF
--- a/scripts/main-menu/ipv6.sh
+++ b/scripts/main-menu/ipv6.sh
@@ -119,7 +119,7 @@ ensure_ipv6_listen_in_file() {
     return 1
   fi
 
-  "$python_bin" <<'PY' "$f"
+  "$python_bin" - "$f" <<'PY'
 import re
 import sys
 from pathlib import Path

--- a/scripts/main-menu/migrate.sh
+++ b/scripts/main-menu/migrate.sh
@@ -599,6 +599,7 @@ gen_nginx_server_block() {
   cat > "$conf" <<NGX
 server {
     listen 80;
+    listen [::]:80;
     server_name ${site};
     root ${root};
     index index.php index.html;

--- a/scripts/vhost-fastcgi
+++ b/scripts/vhost-fastcgi
@@ -3,10 +3,11 @@ fastcgi_cache_path /etc/nginx/mycache/domain.com levels=1:2 keys_zone=domain.com
 server {
   listen 80;
   listen [::]:80;
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
   ssl_certificate /etc/ssl/domain.com/domain.com.crt;
   ssl_certificate_key /etc/ssl/domain.com/domain.com.key;
+  http2 on;
   root /var/www/domain.com;
   index index.php index.html index.htm;
   error_log /var/log/nginx/domain.com.error.log;

--- a/scripts/vhost-nocache
+++ b/scripts/vhost-nocache
@@ -1,10 +1,11 @@
 server {
   listen 80;
   listen [::]:80;
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
   ssl_certificate /etc/ssl/domain.com/domain.com.crt;
   ssl_certificate_key /etc/ssl/domain.com/domain.com.key;
+  http2 on;
   root /var/www/domain.com;
   index index.php index.html index.htm;
   error_log /var/log/nginx/domain.com.error.log;

--- a/scripts/vhost-nocache-invoiceninja
+++ b/scripts/vhost-nocache-invoiceninja
@@ -1,10 +1,11 @@
 server {
   listen 80;
   listen [::]:80;
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
   ssl_certificate /etc/ssl/domain.com/domain.com.crt;
   ssl_certificate_key /etc/ssl/domain.com/domain.com.key;
+  http2 on;
   root /var/www/domain.com/public;
   index index.php index.html index.htm;
   error_log /var/log/nginx/domain.com.error.log;


### PR DESCRIPTION
## Summary
- fix the IPv6 helper so the embedded Python runs from stdin while still receiving the target file path
- add IPv6 listeners to generated server blocks and keep vhost templates aligned with the new style
- drop inline http2 flags from TLS listeners and enable HTTP/2 explicitly inside each server block

## Testing
- script -q -c "printf '1\n\n\n4\n\n' | bash scripts/main-menu/ipv6.sh" /tmp/ipv6.log
- /tmp/run_gen.sh
- nginx -t


------
https://chatgpt.com/codex/tasks/task_e_68e2c52308dc8323966110a95c9e1cfe